### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -164,7 +164,7 @@ Parameter Keys/Values specified in this file take precedence over values defined
 other configuration files. For example:
 
 ```yaml
-KeyPair: my-overriden-keypair
+KeyPair: my-overridden-keypair
 VpcId: vpc-1234abcd
 ```
 
@@ -208,7 +208,7 @@ the effective test configuration would become:
 tests:
   default:
     template: ./template.yaml
-    s3_bucket: my-global-ec2-keypair
+    s3_bucket: my-globally-defined-bucket
     parameters:
       KeyPair: my-global-ec2-keypair
 ```
@@ -237,7 +237,7 @@ would result in this effective test configuration:
 tests:
   default:
     template: ./template.yaml
-    s3_bucket: my-project-ec2-keypair
+    s3_bucket: my-project-s3-bucket
     parameters:
       KeyPair: my-global-ec2-keypair
 ```


### PR DESCRIPTION
1 misspelling.
The Precedence examples kept using keypairs where they meant buckets.
