### PR TITLE
Exclude submodules from lint mechanisms. Closes #701

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Do not add any additional owners to this file, this is being used to ensure that
 # functional tests are run before merge, the taskcat-ci bot will auto-approve once
 # tests have passed
-*       @taskcat-ci @jaymccon @andrew-glenn @tonynv
+*       @aws-ia-ci @jaymccon @andrew-glenn @tonynv

--- a/taskcat/_cfn_lint.py
+++ b/taskcat/_cfn_lint.py
@@ -6,6 +6,7 @@ import cfnlint.core
 import cfnlint.helpers
 from cfnlint.config import ConfigMixIn as CfnLintConfig
 from jsonschema.exceptions import ValidationError
+from taskcat._common_utils import neglect_submodule_templates
 from taskcat._config import Config
 from taskcat._dataclasses import Templates
 
@@ -71,6 +72,9 @@ class Lint:
             for template in self._templates.values():
                 templates.append(template)
                 templates += list(template.descendents)
+            templates = neglect_submodule_templates(
+                self._config.project_root, templates
+            )
             templates = set(templates)
             for template in templates:
                 self._run_checks(template, name, lint_errors, lints)


### PR DESCRIPTION
This change excludes submodules from linting actions. The user typically has no control over submodules and it's not a fair user experience to fail linting based on code that's out of scope.