### PR TITLE
docs: fix links to favicon, logo to tcat.png

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.portray.mkdocs.theme]
-favicon = "https://aws-ia.github.io/assets/img/aws-ia-taskcat.png"
-logo = "https://aws-ia.github.io/assets/img/logonav.png"
+favicon = "https://raw.githubusercontent.com/aws-ia/taskcat/main/assets/docs/images/tcat.png"
+logo = "https://raw.githubusercontent.com/aws-ia/taskcat/main/assets/docs/images/tcat.png"
 name = "material"
 palette = {primary = "black", accent = "orange"}
 


### PR DESCRIPTION
### Overview

Change `favicon` and `logo` to tcat.png to render png logo

Currently the website shows that the logo and the favicon are unavailable:

![image](https://user-images.githubusercontent.com/31919569/150274671-c81b73b4-5e01-4d84-ad95-f9f69bed831e.png)

Whereas [Portray](https://timothycrosley.github.io/portray/) can display both if the values are set correctly to existing links

### Notes

From the `assets/docs/images` directory there is also the `logo.png` image. I think it's the same as `tcat.png`. Since the main GitHub README uses `tcat.png` I opted to do the same