### PR TITLE
Pin markupsafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ botocore>=1.12.21,<2.0
 yattag>=1.10.0,<2.0
 PyYAML~=5.1
 jinja2>=3.1.1,<4.0
+markupsafe==2.0.1
 requests>2.17.0
 jsonschema~=3.0
 docker~=4.0


### PR DESCRIPTION
Reference:
- https://github.com/elastic/ecs/pull/1804/files
- https://github.com/pallets/markupsafe/issues/286#issuecomment-1044491026

Pinning `markupsafe` package for now to work around build failure when installing Jinja2; This is a stop-gap measure for the moment. 