### PR TITLE
Revert to apk installs, alpine-develop now broken

### DIFF
--- a/installer/dockerfiles/alpine-develop/Dockerfile
+++ b/installer/dockerfiles/alpine-develop/Dockerfile
@@ -8,7 +8,7 @@ LABEL version=production
 # Operating Systems
 LABEL container-os=python
 
-RUN apt update && apt install -y gcc
+RUN apk update && apk add gcc python3-dev gcc libc-dev go bash
 RUN pip3 install taskcat --upgrade \
 && pip3 install --index-url https://test.pypi.org/simple/ taskcat  --no-cache-dir --force --upgrade --no-deps
 

--- a/installer/dockerfiles/alpine-main/Dockerfile
+++ b/installer/dockerfiles/alpine-main/Dockerfile
@@ -8,11 +8,8 @@ LABEL version=production
 # Operating Systems
 LABEL container-os=python
 
-#RUN apk update && apk add python3-dev gcc libc-dev
-#RUN apt update && apt install -y libpq-dev gcc python3-dev python3-pip
-RUN apt update && apt install -y gcc
-#RUN pip3 install taskcat
-RUN pip3 install --no-cache-dir taskcat
+RUN apk update && apk add gcc python3-dev gcc libc-dev go bash
+RUN pip3 install --upgrade --no-cache-dir taskcat
 
 
 # Set the work directory


### PR DESCRIPTION
## Overview

The containers for taskcat seem to be attempting to use the apt installer instead of apk on alpine and cannot be built locally due to this.

I'm not sure if CI is overriding the FROM container at build - but it would be better to have the plain Dockerfiles be locally buildable if possible.

## Testing/Steps taken to ensure quality

Tested the GitLab EKS quickstart which encounters this line: https://github.com/aws-quickstart/quickstart-amazon-eks-cluster-resource-provider/blob/main/Dockerfile#L11

Before this change, that command fails (`BuildError The command '/bin/sh -c GOPROXY=direct go mod download' returned a non-zero code: 1`) and loading the container and running the go command shows that go is not found.

After this fix, loading the container and running go shows the go command is found fine.

### Notes

I tried porting the change to the alpine-develop container but it fails on the more elaborate taskcat install command. Given the problems I've had with the alpine-main, I would suggest that this failure might already be happening independent of my changes.

## Testing Instructions

1. Build the container with this file.
2. Load the container using bash as the entrypoint
3. run `go` and verify that you do not get an error that it is missing.

 How to test this PR Start after checking out this branch (bulleted)
 * Include test case, and expected output
