### PR TITLE
Add additional Dockerfile packaging logging during debug

### DIFF
--- a/taskcat/cfg/config_schema.json
+++ b/taskcat/cfg/config_schema.json
@@ -34,10 +34,19 @@
                 },
                 "parameters": {
                     "additionalProperties": {
-                        "anyOf": [
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "boolean"
+                            },
                             {
                                 "items": {
-                                    "anyOf": [
+                                    "oneOf": [
                                         {
                                             "type": "integer"
                                         },
@@ -47,15 +56,6 @@
                                     ]
                                 },
                                 "type": "array"
-                            },
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "string"
                             }
                         ]
                     },
@@ -227,10 +227,19 @@
                 },
                 "parameters": {
                     "additionalProperties": {
-                        "anyOf": [
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "boolean"
+                            },
                             {
                                 "items": {
-                                    "anyOf": [
+                                    "oneOf": [
                                         {
                                             "type": "integer"
                                         },
@@ -240,15 +249,6 @@
                                     ]
                                 },
                                 "type": "array"
-                            },
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "string"
                             }
                         ]
                     },
@@ -394,10 +394,19 @@
                 },
                 "parameters": {
                     "additionalProperties": {
-                        "anyOf": [
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "boolean"
+                            },
                             {
                                 "items": {
-                                    "anyOf": [
+                                    "oneOf": [
                                         {
                                             "type": "integer"
                                         },
@@ -407,15 +416,6 @@
                                     ]
                                 },
                                 "type": "array"
-                            },
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "integer"
-                            },
-                            {
-                                "type": "string"
                             }
                         ]
                     },


### PR DESCRIPTION
## Overview

When running `taskcat -d package` where a taskcat project uses `Dockerfile` packaging the loggin output is only the last `
n` lines of the docker run output. 

## Testing/Steps taken to ensure quality

ran task package against a quickstart with `Dockerfile` for it's function packaging. 

### Notes

Optional. Caveats, Alternatives, Other relevant information.

## Testing Instructions

 How to test this PR Start after checking out this branch (bulleted)
 run `taskcat -d package` in a taskcat project with `Dockerfile` packaging 
