### PR TITLE
key prefix validation

### DIFF
--- a/taskcat/_dataclasses.py
+++ b/taskcat/_dataclasses.py
@@ -127,7 +127,8 @@ TagValue = NewType("TagValue", str)
 S3Acl = NewType("S3Acl", str)
 Region = NewType("Region", str)
 AlNumDash = NewType("AlNumDash", str)
-ProjectName = NewType("ProjectName", AlNumDash)
+AlNumDashSlash = NewType("AlNumDashSlash", str)
+ProjectName = NewType("ProjectName", AlNumDashSlash)
 S3BucketName = NewType("S3BucketName", AlNumDash)
 TestName = NewType("TestName", AlNumDash)
 AzId = NewType("AzId", str)
@@ -200,6 +201,19 @@ class AlNumDashField(FieldEncoder):
 
 
 JsonSchemaMixin.register_field_encoders({AlNumDash: AlNumDashField()})
+
+
+class AlNumDashSlashField(FieldEncoder):
+    @property
+    def json_schema(self):
+        return {
+            "type": "string",
+            "pattern": r"^[a-z0-9-/]*$",
+            "description": "accepts lower case letters, numbers, -, /",
+        }
+
+
+JsonSchemaMixin.register_field_encoders({AlNumDashSlash: AlNumDashSlashField()})
 
 
 class AzIdField(FieldEncoder):

--- a/taskcat/cfg/config_schema.json
+++ b/taskcat/cfg/config_schema.json
@@ -203,7 +203,7 @@
                     "examples": [
                         "my-project-name"
                     ],
-                    "pattern": "^[a-z0-9-]*$",
+                    "pattern": "^[a-z0-9-/]*$",
                     "type": "string"
                 },
                 "org_id": {


### PR DESCRIPTION
Just a quick PR to modify the `project.name` regex validation to allow a forward slash. 