### PR TITLE
New Psuedo Param: [taskcat_git_branch]

### DIFF
--- a/taskcat/_config.py
+++ b/taskcat/_config.py
@@ -388,6 +388,7 @@ class Config:
                 region = region_objects[test_name][region_name]
                 s3bucket = bucket_objects[test_name][region_name]
                 parameters[test_name][region_name] = ParamGen(
+                    self.project_root,
                     region_params,
                     s3bucket.name,
                     region.name,

--- a/tests/data/git_branch_without_repo/.taskcat.yml
+++ b/tests/data/git_branch_without_repo/.taskcat.yml
@@ -1,0 +1,19 @@
+project:
+  template: template1.yaml
+  regions:
+  - us-east-1
+  parameters:
+    ProjectVar: set_in_project
+    OverridenVar: set_in_project
+tests:
+  default:
+    parameters:
+      MyVar: set_in_test
+      OverridenVar: set_in_test
+      GitBranch: $[taskcat_git_branch]
+    regions:
+    - us-west-2
+  other:
+    template: other_template.yaml
+    parameters:
+      ProjectVar: set_in_test


### PR DESCRIPTION
A new use-case has emerged where passing in the current git branch as a parameter is desirable. 

Therefore, this PR introduces the `$[taskcat_git_branch]` psuedo-parameter. Unit tests are included. If the psuedo-parameter is used in a project root that's not a git repo, and exception is raised. 