### PR TITLE
Requirements pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ jsonschema~=3.0
 docker~=4.0
 dulwich~=0.19
 dataclasses;python_version<"3.7"
-dataclasses-jsonschema>=2.9.0,<3.0
+dataclasses-jsonschema>=2.9.0,<2.15.2
 pip


### PR DESCRIPTION
dataclasses-jsonschema v 2.15.2 results in a typeerror; limiting install to 2.15.1 is a workaround for now. 