### PR TITLE
Add AMI updater support for Ubuntu Server 22.04 LTS and SLES 15 SP4

### DIFF
--- a/taskcat/cfg/amiupdater.cfg.yml
+++ b/taskcat/cfg/amiupdater.cfg.yml
@@ -117,8 +117,15 @@ global:
     US2004HVM:
       name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????*
       owner-id: '099720109477'
+    US2204HVM:
+      name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-????????*
+      owner-id: '099720109477'
     US2004HVMARM:
       name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-????????*
+      owner-id: '099720109477'
+      architecture: arm64
+    US2204HVMARM:
+      name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-????????*
       owner-id: '099720109477'
       architecture: arm64
     WS2012R2:

--- a/taskcat/cfg/amiupdater.cfg.yml
+++ b/taskcat/cfg/amiupdater.cfg.yml
@@ -117,13 +117,13 @@ global:
     US2004HVM:
       name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-????????*
       owner-id: '099720109477'
-    US2204HVM:
-      name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-????????*
-      owner-id: '099720109477'
     US2004HVMARM:
       name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-????????*
       owner-id: '099720109477'
       architecture: arm64
+    US2204HVM:
+      name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-????????*
+      owner-id: '099720109477'
     US2204HVMARM:
       name: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-????????*
       owner-id: '099720109477'

--- a/taskcat/cfg/amiupdater.cfg.yml
+++ b/taskcat/cfg/amiupdater.cfg.yml
@@ -100,6 +100,9 @@ global:
       name: suse-sles-15-v????????-hvm-ssd-arm64
       owner-alias: amazon
       architecture: arm64
+    SLES15SP4HVM:
+      name: suse-sles-15-sp4-v????????-hvm-ssd-x86_64
+      owner-alias: amazon
     US1404HVM:
       name: ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-????????*
       owner-id: '099720109477'


### PR DESCRIPTION
Related to https://github.com/aws-quickstart/quickstart-linux-bastion/pull/176