### PR TITLE
Migrating to pathspec (gitignore syntax) method for excludes

### DIFF
--- a/THIRD_PARTY
+++ b/THIRD_PARTY
@@ -1,0 +1,8 @@
+  Copyright 2022, Caleb P. Burns  <2126043+cpburnz@users.noreply.github.com>
+  
+  SPDX-License-Identifier: MPL-2.0
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  
+  https://github.com/cpburnz/python-pathspec/releases/tag/v0.10.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pathspec
 reprint
 tabulate>=0.8.2,<1.0
 cfn_lint>=0.13.0,<1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pathspec
+pathspec==0.10.3
 reprint
 tabulate>=0.8.2,<1.0
 cfn_lint>=0.13.0,<1.0


### PR DESCRIPTION
This PR introduces the `pathspec` library to handle s3 excludes via the gitignore syntax.