### PR TITLE
Bump cfn-lint minimum version to add nodejs18.x lambda runtime support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pathspec==0.10.3
 reprint
 tabulate>=0.8.2,<1.0
-cfn_lint>=0.13.0,<1.0
+cfn_lint>=0.72.0,<1.0
 setuptools>=40.4.3
 boto3>=1.9.21,<2.0
 botocore>=1.12.21,<2.0


### PR DESCRIPTION
## Overview

This PR bumps the minimum cfn-lint version to include nodejs18.x lambda runtime support.
See this closed issue from the cfn-lint repo for more information: https://github.com/aws-cloudformation/cfn-lint/issues/2494.

## Testing/Steps taken to ensure quality

Installed and built locally.

### Notes

n/a

## Testing Instructions

Attempt to lint a template which includes a lambda with the following runtime:

`Runtime: nodejs18.x`

and you should not receive the following error:

`[Check if properties have a valid value] You must specify a valid value for Runtime (nodejs18.x). Valid
                                                             values are ["dotnet6", "dotnetcore1.0", "dotnetcore2.0",
                                                             "dotnetcore2.1", "dotnetcore3.1", "go1.x", "java11", "java8",
                                                             "java8.al2", "nodejs", "nodejs10.x", "nodejs12.x", "nodejs14.x",
                                                             "nodejs16.x", "nodejs4.3", "nodejs4.3-edge", "nodejs6.10",
                                                             "nodejs8.10", "provided", "provided.al2", "python2.7", "python3.6",
                                                             "python3.7", "python3.8", "python3.9", "ruby2.5", "ruby2.7"]`