### PR TITLE
Linking SecretsManager wrapper to regex

### DIFF
--- a/taskcat/_template_params.py
+++ b/taskcat/_template_params.py
@@ -172,6 +172,10 @@ class ParamGen:
 
             # $[taskcat_ssm_X]
             self._get_ssm_param_value_wrapper(self.RE_SSM_PARAMETER)
+
+            # $[taskcat_secretsmanager_X]
+            self._get_secretsmanager_param_value_wrapper(self.RE_SECRETSMANAGER_PARAMETER)
+
             # $[taskcat_current_region]
             self._regex_replace_param_value(
                 self.RE_CURRENT_REGION, self._gen_current_region()


### PR DESCRIPTION
The `$[taskcat_secretsmanager_X]` psuedoparam wasn't linked to the parsing function. Oops. 