### PR TITLE
Detect if inputfile is taskcat config or CloudFormation template, Add unittests

### DIFF
--- a/taskcat/_config.py
+++ b/taskcat/_config.py
@@ -153,6 +153,7 @@ class Config:
         try:
             with open(str(file_path), "r", encoding="utf-8") as file_handle:
                 config_dict = yaml.safe_load(file_handle)
+                LOG.debug(f"file_path={file_path}, file_handle={file_handle}")
             return config_dict
         except Exception as e:  # pylint: disable=broad-except
             LOG.warning(f"failed to load config from {file_path}")

--- a/taskcat/testing/base_test.py
+++ b/taskcat/testing/base_test.py
@@ -86,11 +86,19 @@ class BaseTest(Test):
         input_file_path: Path = project_root_path / input_file
         # pylint: disable=too-many-arguments
         args = _build_args(enable_sig_v2, regions, GLOBAL_ARGS.profile)
-        config = Config.create(
-            project_root=project_root_path,
-            project_config_path=input_file_path,
-            args=args
-            # TODO: detect if input file is taskcat config or CloudFormation template
+
+        # Detect if input file is taskcat config or CloudFormation template
+        if '.taskcat.yml' in input_file or '.taskcat.yaml' in input_file:
+            config = Config.create(
+                project_root=project_root_path,
+                project_config_path=input_file_path,
+                args=args
+        )
+        else:
+            config = Config.create(
+                project_root=project_root_path,
+                template_file=input_file_path,
+                args=args
         )
 
         return cls(config)

--- a/tests/testing_module/test_base.py
+++ b/tests/testing_module/test_base.py
@@ -19,6 +19,9 @@ class TestBaseTest(unittest.TestCase):
         cls.input_file = ".taskcat.yml"
         cls.project_root_path = Path(__file__).parent / "../data/nested-fail"
         cls.input_file_path = cls.project_root_path / cls.input_file
+        cls.template_file = (
+            Path(__file__).parent / "../data/nested-fail/templates/test.template.yaml"
+        )
 
         cls.base_config = Config.create(
             project_root=cls.project_root_path,
@@ -54,8 +57,38 @@ class TestBaseTest(unittest.TestCase):
 
         self.assertIsInstance(base, Test)
 
-    def test_from_file(self):
+    @patch("taskcat.testing.base_test._build_args")
+    @patch("taskcat.testing.base_test.BaseTest")
+    def test_from_file_template_yaml(self, base_test_mock, args_mock):
+        # given
+        mock_out = base_test_mock.return_value
 
+        # when
+        mock_out.from_file(
+            project_root=self.project_root_path, input_file=self.template_file
+        )
+
+        # then
+        base_test_mock.return_value.from_file.assert_called_with(
+            project_root=self.project_root_path,
+            input_file=self.template_file
+        )
+
+    @patch("taskcat.testing.base_test._build_args")
+    @patch("taskcat.testing.base_test.BaseTest")
+    def test_from_file_taskcat_yaml(self, base_test_mock, args_mock):
+        # given
+        mock_out = base_test_mock.return_value
+
+        # when
+        mock_out.from_file(project_root=self.project_root_path)
+
+        # then
+        base_test_mock.return_value.from_file.assert_called_with(
+            project_root=self.project_root_path
+        )
+
+    def test_from_file(self):
         base = BaseTest.from_file(project_root=self.project_root_path)
 
         self.assertIsInstance(base, BaseTest, "Should return an instance of BaseTest.")


### PR DESCRIPTION
… unittests

## Overview

Addressing the issue mentioned [here](https://github.com/aws-ia/taskcat/issues/662) . When passing a template file it fails
`taskcat test run -i TestTemplate.yaml. I get [Error] : ConstructorError could not determine a constructor for the tag '!Ref'`  

## Testing/Steps taken to ensure quality

Ran the following tests

` taskcat --profile ${AWS_PROFILE} test run -i Template_file.yaml`

 
` taskcat --profile ${AWS_PROFILE} test run`

` taskcat --profile ${AWS_PROFILE} test run -i .taskcat.yml`

_Edit by @andrew-glenn: Closes #662_
