### PR TITLE
Empty taskcat_overrides.yml file -- Check if override_params is None

### DIFF
--- a/taskcat/_config.py
+++ b/taskcat/_config.py
@@ -107,7 +107,8 @@ class Config:
             overrides = BaseConfig().to_dict()
             with open(str(overrides_path), "r", encoding="utf-8") as file_handle:
                 override_params = yaml.safe_load(file_handle)
-            overrides["project"]["parameters"] = override_params
+            overrides["project"]["parameters"] = override_params if override_params else {}
+            LOG.debug(f"Value of override_params={override_params}")
             sources.append({"source": str(overrides_path), "config": overrides})
 
         # environment variables


### PR DESCRIPTION
_Edit by @andrew-glenn: Closes #780_

## Overview

This is related to the issue documented [here](https://github.com/aws-ia/taskcat/issues/780) 

## Testing/Steps taken to ensure quality

I created a empty `.taskcat_overrides.yml` file and tested multiple templates. 

### Notes

Optional. Caveats, Alternatives, Other relevant information.

## Testing Instructions

 How to test this PR Start after checking out this branch (bulleted)
 *  ```
taskcat -d --profile ${AWS_PROFILE} test run 
 _            _             _   
| |_ __ _ ___| | _____ __ _| |_ 
| __/ _` / __| |/ / __/ _` | __|
| || (_| \__ \   < (_| (_| | |_ 
 \__\__,_|___/_|\_\___\__,_|\__|
                                


version 0.9.36
[INFO   ] : Linting passed for file: /Users/ramacjay/source/tfc/cfn101-workshop/code/solutions/conditions/condition-output.yaml
[S3: -> ] s3://tcat-linting-and-testing-workshop-rrrr/condition-output/condition-resource-property.yaml
[S3: -> ] s3://tcat-linting-and-testing-workshop-rrrr/condition-output/condition-output.yaml
[S3: -> ] s3://tcat-linting-and-testing-workshop-rrrr/condition-output/condition-resource.yaml
[INFO   ] : ┏ stack Ⓜ tCaT-condition-output-default-xxxx                                                                         [INFO   ] : ┣ region: us-east-1                                                                                                                              [INFO   ] : ┗ status: CREATE_COMPLETE                                                                                                                        [INFO   ] : ┏ stack Ⓜ tCaT-condition-output-default-xxxx                                                                         [INFO   ] : ┣ region: us-east-2                                                                                                                              [INFO   ] : ┗ status: CREATE_COMPLETE                                                                                                                        [INFO   ] : Reporting on arn:aws:cloudformation:us-east-1:xxxx:stack/tCaT-condition-output-default-xxxx/xxxx
[INFO   ] : Reporting on arn:aws:cloudformation:us-east-2:xxxx:stack/tCaT-condition-output-default-xxxx/4b700190-ba13-11ed-88cc-xxxx
[INFO   ] : Deleting stack: arn:aws:cloudformation:us-east-2:xxxx:stack/tCaT-condition-output-default-zzzz/xxxx
[INFO   ] : Deleting stack: arn:aws:cloudformation:us-east-1:xxxx:stack/tCaT-condition-output-default-zzzz/zzzz
[INFO   ] : ┏ stack Ⓜ tCaT-condition-output-default-xxxx                                                                         [INFO   ] : ┣ region: us-east-1                                                                                                                              [INFO   ] : ┗ status: DELETE_COMPLETE                                                                                                                        [INFO   ] : ┏ stack Ⓜ tCaT-condition-output-default-xxxx                                                                         [INFO   ] : ┣ region: us-east-2                                                                                                                              [INFO   ] : ┗ status: DELETE_COMPLETE                                                                                                                        [INFO   ] : Will not delete bucket created outside of taskcat tcat-xxxx-xxxx
```