### PR TITLE
Show message on terminal before exiting -- Add a message about missing test

### DIFF
--- a/taskcat/testing/_cfn_test.py
+++ b/taskcat/testing/_cfn_test.py
@@ -108,6 +108,10 @@ class CFNTest(BaseTest):  # pylint: disable=too-many-instance-attributes
         parameters = self.config.get_rendered_parameters(buckets, regions, templates)
         tests = self.config.get_tests(templates, regions, buckets, parameters)
 
+        # Check if we have any valid test if NOT log a message
+        if not tests:
+            LOG.warning("No valid test found.")
+
         # pre-hooks
         execute_hooks("prehooks", self.config, tests, parameters)
 


### PR DESCRIPTION
## Overview
This is related to the issue mentioned [here](https://github.com/aws-ia/taskcat/issues/743) when you run taskcat without a valid test it simply exists

Added a warning message about missing tests 

## Testing/Steps taken to ensure quality

Ran test locally and verified the changes

```
taskcat -d --profile ... test run -t foo,bar,baz
 _            _             _   
| |_ __ _ ___| | _____ __ _| |_ 
| __/ _` / __| |/ / __/ _` | __|
| || (_| \__ \   < (_| (_| | |_ 
 \__\__,_|___/_|\_\___\__,_|\__|
                                


version 0.9.36
[WARN   ] : No valid test found.
```


_Edit by @andrew-glenn: Closes #743_