### PR TITLE
Fixing schema documentation URL in GENERAL_USAGE.

### DIFF
--- a/docs/usage/GENERAL_USAGE.md
+++ b/docs/usage/GENERAL_USAGE.md
@@ -35,10 +35,10 @@ The example used here is very simple, you would most likely leverage other pytho
 taskcat has several configuration files which can be used to set behaviors in a flexible way.
 
 #### Global config
-`~/.taskcat.yml` provides global settings that become defaults for all projects. Please see our [schema reference](/docs/schema/taskcat_schema.html) for specific configuration options that are available.
+`~/.taskcat.yml` provides global settings that become defaults for all projects. Please see our [schema reference](https://aws-ia.github.io/taskcat/docs/schema/taskcat_schema/) for specific configuration options that are available.
 
 #### Project config
-`<PROJECT_ROOT>/.taskcat.yml` provides project specific configuration. Please see our [schema reference](/docs/schema/taskcat_schema.html) for specific configuration options that are available.
+`<PROJECT_ROOT>/.taskcat.yml` provides project specific configuration. Please see our [schema reference](https://aws-ia.github.io/taskcat/docs/schema/taskcat_schema/) for specific configuration options that are available.
 
 
 #### Precedence


### PR DESCRIPTION
## Overview

This PR fixes the schema URL in `GENERAL_USAGE.md`, pointing it to the right location.

## Testing/Steps taken to ensure quality

I wasn't able to test it locally since I'm not sure how to build the docs page.

### Notes

None.

## Testing Instructions

None.