### PR TITLE
Adding: `role_name` to list of inherited items so propagation works

### DIFF
--- a/taskcat/_dataclasses.py
+++ b/taskcat/_dataclasses.py
@@ -656,6 +656,7 @@ PROPOGATE_ITEMS = [
     "s3_regional_buckets",
     "prehooks",
     "posthooks",
+    "role_name"
 ]
 
 


### PR DESCRIPTION
This PR allows the `role_arn` property to propagate down from `project`. 

Closes: #618 