### PR TITLE
Add role_arn to delete function in stack.py

### DIFF
--- a/taskcat/_cfn/stack.py
+++ b/taskcat/_cfn/stack.py
@@ -516,8 +516,17 @@ class Stack:  # pylint: disable=too-many-instance-attributes
         self._resources = resources
 
     @staticmethod
-    def delete(client, stack_id) -> None:
-        client.delete_stack(StackName=stack_id)
+    def delete(
+            client, 
+            stack_id, 
+            role_arn: RoleARN = None,
+            ) -> None:
+        delete_options = {
+            "StackId": stack_id,
+        }
+        if role_arn:
+            delete_options["RoleARN"] = role_arn
+        client.delete_stack(**create_options)
         LOG.info(f"Deleting stack: {stack_id}")
 
     def update(self, *args, **kwargs):


### PR DESCRIPTION
## Overview

Update stack.py delete function to use an optional role_arn parameter during delete stack.

## Testing/Steps taken to ensure quality

Peer reviewed but needs additional testing to validate.

### Notes

Optional. Caveats, Alternatives, Other relevant information.

## Testing Instructions

 How to test this PR Start after checking out this branch (bulleted)
Use role_name in project to create a stack and confirm the delete is also done by the same role.
