### PR TITLE
Minor typo in some commands help

### DIFF
--- a/taskcat/_cli_modules/test.py
+++ b/taskcat/_cli_modules/test.py
@@ -45,7 +45,7 @@ class Test:
         :param region: region stack is in
         :param stack_name: name of parent stack
         :param resource_name: logical id of child stack that will be re-launched
-        :param config_file: path to either a taskat project config file or a
+        :param config_file: path to either a taskcat project config file or a
         CloudFormation template
         :param project_root: root path of the project relative to input_file
         :param no_delete: don't delete stacks after test is complete
@@ -129,7 +129,7 @@ class Test:
         """tests whether CloudFormation templates are able to successfully launch
         :param test_names: comma separated list of tests to run
         :param regions: comma separated list of regions to test in
-        :param input_file: path to either a taskat project config file or a CloudFormation template
+        :param input_file: path to either a taskcat project config file or a CloudFormation template
         :param project_root: root path of the project relative to input_file
         :param no_delete: don't delete stacks after test is complete
         :param lint_disable: disable cfn-lint checks

--- a/taskcat/_cli_modules/upload.py
+++ b/taskcat/_cli_modules/upload.py
@@ -32,7 +32,7 @@ class Upload:
     ):  # pylint: disable=too-many-locals
         """does lambda packaging and uploads to s3
 
-        :param config_file: path to taskat project config file
+        :param config_file: path to taskcat project config file
         :param enable_sig_v2: enable legacy sigv2 requests for auto-created buckets
         :param bucket_name: set bucket name instead of generating it. If regional
         buckets are enabled, will use this as a prefix


### PR DESCRIPTION
## Overview

Noticed **taskat** instead of **taskcat** in `test run`, `test retry` subcommands and `upload` commands.

## Testing/Steps taken to ensure quality

re-run the command output the correct name after this trivial modification

### Notes

Optional. Caveats, Alternatives, Other relevant information.

## Testing Instructions

 How to test this PR Start after checking out this branch (bulleted)
 * Include test case, and expected output
