### PR TITLE
Expand schemas to accept mx

### DIFF
--- a/taskcat/_dataclasses.py
+++ b/taskcat/_dataclasses.py
@@ -156,7 +156,7 @@ class RegionField(FieldEncoder):
     def json_schema(self):
         return {
             "type": "string",
-            "pattern": r"^(ap|eu|us|sa|ca|cn|af|me|il|us-gov)-(central|south|north|east|"
+            "pattern": r"^(ap|eu|us|sa|ca|cn|af|me|il|mx|us-gov)-(central|south|north|east|"
             r"west|southeast|southwest|northeast|northwest)-[0-9]$",
             "description": "AWS Region name",
             "examples": ["us-east-1"],

--- a/taskcat/cfg/config_schema.json
+++ b/taskcat/cfg/config_schema.json
@@ -13,7 +13,7 @@
                         "examples": [
                             "us-east-1"
                         ],
-                        "pattern": "^(ap|eu|us|sa|ca|cn|af|me|il|us-gov)-(central|south|north|east|west|southeast|southwest|northeast|northwest)-[0-9]$",
+                        "pattern": "^(ap|eu|us|sa|ca|cn|af|me|il|mx|us-gov)-(central|south|north|east|west|southeast|southwest|northeast|northwest)-[0-9]$",
                         "type": "string"
                     },
                     "type": "array"
@@ -83,7 +83,7 @@
                         "examples": [
                             "us-east-1"
                         ],
-                        "pattern": "^(ap|eu|us|sa|ca|cn|af|me|il|us-gov)-(central|south|north|east|west|southeast|southwest|northeast|northwest)-[0-9]$",
+                        "pattern": "^(ap|eu|us|sa|ca|cn|af|me|il|mx|us-gov)-(central|south|north|east|west|southeast|southwest|northeast|northwest)-[0-9]$",
                         "type": "string"
                     },
                     "type": "array"
@@ -144,7 +144,7 @@
                         "examples": [
                             "us-east-1"
                         ],
-                        "pattern": "^(ap|eu|us|sa|ca|cn|af|me|il|us-gov)-(central|south|north|east|west|southeast|southwest|northeast|northwest)-[0-9]$",
+                        "pattern": "^(ap|eu|us|sa|ca|cn|af|me|il|mx|us-gov)-(central|south|north|east|west|southeast|southwest|northeast|northwest)-[0-9]$",
                         "type": "string"
                     },
                     "type": "array"
@@ -276,7 +276,7 @@
                         "examples": [
                             "us-east-1"
                         ],
-                        "pattern": "^(ap|eu|us|sa|ca|cn|af|me|il|us-gov)-(central|south|north|east|west|southeast|southwest|northeast|northwest)-[0-9]$",
+                        "pattern": "^(ap|eu|us|sa|ca|cn|af|me|il|mx|us-gov)-(central|south|north|east|west|southeast|southwest|northeast|northwest)-[0-9]$",
                         "type": "string"
                     },
                     "type": "array"
@@ -360,7 +360,7 @@
                         "examples": [
                             "us-east-1"
                         ],
-                        "pattern": "^(ap|eu|us|sa|ca|cn|af|me|il|us-gov)-(central|south|north|east|west|southeast|southwest|northeast|northwest)-[0-9]$",
+                        "pattern": "^(ap|eu|us|sa|ca|cn|af|me|il|mx|us-gov)-(central|south|north|east|west|southeast|southwest|northeast|northwest)-[0-9]$",
                         "type": "string"
                     },
                     "type": "array"
@@ -444,7 +444,7 @@
                         "examples": [
                             "us-east-1"
                         ],
-                        "pattern": "^(ap|eu|us|sa|ca|cn|af|me|il|us-gov)-(central|south|north|east|west|southeast|southwest|northeast|northwest)-[0-9]$",
+                        "pattern": "^(ap|eu|us|sa|ca|cn|af|me|il|mx|us-gov)-(central|south|north|east|west|southeast|southwest|northeast|northwest)-[0-9]$",
                         "type": "string"
                     },
                     "type": "array"


### PR DESCRIPTION
## Overview

Although `mx-central-1` was recently added, the schema was not updated to accept `mx-` regions, and attempting to use that region fails.

## Testing/Steps taken to ensure quality

Not familiar with this ecosystem so only testing was applying the same changes to production files, and that works.

## Testing Instructions

Try including `mx-central-1` in a `.taskcat.yml` and running `taskcat`.  Without these changes it fails due to schema violation.  With these changes it works as expected.
