### PR TITLE
fix: Add support for ap-east-2 AWS region

### DIFF
--- a/taskcat/regions_to_partitions.py
+++ b/taskcat/regions_to_partitions.py
@@ -1,6 +1,7 @@
 REGIONS = {
     "af-south-1": "aws",
     "ap-east-1": "aws",
+    "ap-east-2": "aws",
     "ap-northeast-1": "aws",
     "ap-northeast-2": "aws",
     "ap-northeast-3": "aws",
@@ -48,6 +49,7 @@ PARTITIONS = {
     "aws": [
         "af-south-1",
         "ap-east-1",
+        "ap-east-2",
         "ap-northeast-1",
         "ap-northeast-2",
         "ap-northeast-3",


### PR DESCRIPTION
- Updated regions_to_partitions.py to include ap-east-2 region mapping
- Fixes 'cannot find the S3 hostname for region ap-east-2' error
- Added ap-east-2 to both REGIONS dictionary and PARTITIONS['aws'] list
- All existing tests pass, region mapping functionality verified

Resolves issue with S3 hostname resolution for ap-east-2 region.

## Overview

Brief description of what this PR does, and why it is needed (use case)? This fixes [GitHub issue #861](https://github.com/aws-ia/taskcat/issues/861)

## Testing/Steps taken to ensure quality

How did you validate the changes in this PR?

### Notes

N/A

## Testing Instructions

 How to test this PR Start after checking out this branch (bulleted)
 * Include test case, and expected output
